### PR TITLE
Add LiveStream OEmbed support

### DIFF
--- a/lib/embeds.php
+++ b/lib/embeds.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace PCCFramework\Embeds;
+
+/**
+ * Add OEmbed provider for livestream.com.
+ *
+ * @return null
+ */
+function init_livestream()
+{
+    wp_oembed_add_provider('https://livestream.com/accounts/*/events/*', 'https://livestream.com/oembed');
+    wp_oembed_add_provider('https://livestream.com/accounts/*/events/*/videos/*', 'https://livestream.com/oembed');
+    wp_oembed_add_provider('https://livestream.com/*/events/*', 'https://livestream.com/oembed');
+    wp_oembed_add_provider('https://livestream.com/*/events/*/videos/*', 'https://livestream.com/oembed');
+    wp_oembed_add_provider('https://livestream.com/*/*', 'https://livestream.com/oembed');
+    wp_oembed_add_provider('https://livestream.com/*/*/videos/*', 'https://livestream.com/oembed');
+}

--- a/pcc-framework.php
+++ b/pcc-framework.php
@@ -100,3 +100,10 @@ if (is_admin()) {
     add_filter('attachment_fields_to_edit', '\\PCCFramework\\PostTypes\\Attachment\\data', 10, 2);
     add_action('edit_attachment', '\\PCCFramework\\PostTypes\\Attachment\\save');
 }
+
+/**
+ * Register new embed providers.
+ */
+require_once dirname(__FILE__) . "/lib/embeds.php";
+
+PCCFramework\Embeds\init_livestream();


### PR DESCRIPTION
* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

This PR adds WordPress OEmbed support to LiveStream videos.

## Steps to test

1. Paste a link to a LiveStream video into the editor.

**Expected behavior:** It embeds automatically.

## Additional information

See:

- https://wordpress.org/support/article/embeds/#adding-support-for-an-oembed-enabled-site
- https://oembed.com/#section7

## Related issues

Not applicable.
