### PR TITLE
Fix newsletter link in Recent Content block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Changelog #
+## 1.3.1 ##
+
+**Patches**
+
+* Fix broken newsletter signup link in Recent Content block: #66
+
 ## 1.3.0 ##
 
 **Minor Changes**

--- a/lib/blocks/recent-content.php
+++ b/lib/blocks/recent-content.php
@@ -97,7 +97,9 @@ function render_callback($attributes)
                     <?= __('Our monthly newsletters keep you updated on news about the community.', 'pcc-framework'); ?>
                 </p>
                 <p class="wp-block-button is-style-secondary">
-                    <a class="wp-block-button__link" href="<?= $newsletter_link ?>"><?= __('Sign Up', 'pcc-framework'); ?></a>
+                    <a class="wp-block-button__link" href="<?= $newsletter_link ?>">
+                        <?= __('Sign Up', 'pcc-framework'); ?>
+                    </a>
                 </p>
         </li>
         </ul>

--- a/lib/blocks/recent-content.php
+++ b/lib/blocks/recent-content.php
@@ -81,7 +81,13 @@ function render_callback($attributes)
         </li>
         <?php }
         wp_reset_postdata();
-    ?>
+        $newsletter_link = (function_exists('\PlatformCoop\Utils\get_config_option'))
+        ? get_config_option(
+            'signup_link',
+            'https://lists.riseup.net/www/info/platformcoop-newsletter'
+        )
+        : 'https://lists.riseup.net/www/info/platformcoop-newsletter';
+        ?>
         <li class="card card--7">
             <div class="card__details">
                 <header class="text">
@@ -91,7 +97,7 @@ function render_callback($attributes)
                     <?= __('Our monthly newsletters keep you updated on news about the community.', 'pcc-framework'); ?>
                 </p>
                 <p class="wp-block-button is-style-secondary">
-                    <a class="wp-block-button__link" href="#"><?= __('Sign Up', 'pcc-framework'); ?></a>
+                    <a class="wp-block-button__link" href="<?= $newsletter_link ?>"><?= __('Sign Up', 'pcc-framework'); ?></a>
                 </p>
         </li>
         </ul>

--- a/pcc-framework.php
+++ b/pcc-framework.php
@@ -9,7 +9,7 @@
  * Domain Path:     /languages
  * License:         BSD 3-Clause "New" License
  * License URI:     https://opensource.org/licenses/BSD-3-Clause
- * Version:         1.3.0
+ * Version:         1.3.1
  *
  * @package         PCCFramework
  */

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ License: BSD 3-Clause "New" License
 License URI: https://opensource.org/licenses/BSD-3-Clause
 Requires at least: 5.2.3
 Tested up to: 5.2.3
-Stable tag: 1.3.0
+Stable tag: 1.3.1
 
 [![License](https://badgen.net/github/license/platform-coop-toolkit/pcc-framework)](https://github.com/platform-coop-toolkit/pcc-framework/blob/master/LICENSE.md) [![Status](https://badgen.net/github/status/platform-coop-toolkit/pcc-framework)](https://circleci.com/gh/platform-coop-toolkit/pcc-framework/tree/master) [![GitHub Release](https://badgen.net/github/release/platform-coop-toolkit/pcc-framework)](https://github.com/platform-coop-toolkit/pcc-framework/releases/latest)
 
@@ -40,6 +40,12 @@ Custom Taxonomies:
 None yet.
 
 == Changelog ==
+= 1.3.1 =
+
+**Patches**
+
+* Fix broken newsletter signup link in Recent Content block: #66
+
 = 1.3.0 =
 
 **Minor Changes**


### PR DESCRIPTION
* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

Fixes broken newsletter signup link in Recent Content block.

## Steps to test

1. Add a Recent Content block.

**Expected behavior:** Verify that newsletter link works.

## Additional information

Not applicable.

## Related issues

- #65 
