### PR TITLE
Add field for Twitter username (see platform-coop-toolkit/pcc#120)

### DIFF
--- a/lib/posttypes/pcc-person.php
+++ b/lib/posttypes/pcc-person.php
@@ -97,4 +97,13 @@ function data()
         'description' =>
             __('A hyperlink organization with which this person is primarily affiliated.', 'pcc-framework'),
     ]);
+
+    $cmb->add_field([
+        'name'        => __('Twitter Username', 'pcc-framework'),
+        'id'          => $prefix . 'twitter_username',
+        'attributes'  => [ 'placeholder' => '@twitter' ],
+        'type'        => 'text',
+        'description' =>
+            __('The person&rsquo;s Twitter username.', 'pcc-framework'),
+    ]);
 }


### PR DESCRIPTION
* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

Adds Twitter username field to People post type to support platform-coop-toolkit/pcc#120.

## Steps to test

1. Edit a People post type.

**Expected behavior:** There's a field for Twitter username.

## Additional information

Not applicable.

## Related issues

- platform-coop-toolkit/pcc#120
