### PR TITLE
Adjust participant fields

### DIFF
--- a/lib/posttypes/pcc-person.php
+++ b/lib/posttypes/pcc-person.php
@@ -75,15 +75,15 @@ function data()
     ]);
 
     $cmb->add_field([
-        'name' => __('Title', 'pcc-framework'),
+        'name' => __('Title or Occupation', 'pcc-framework'),
         'id'   => $prefix . 'title',
         'type' => 'text',
         'description' =>
-            __('The job title of this person.', 'pcc-framework'),
+            __('The job title or occupation of this person.', 'pcc-framework'),
     ]);
 
     $cmb->add_field([
-        'name' => __('Organization', 'pcc-framework'),
+        'name' => __('Project or Organization', 'pcc-framework'),
         'id'   => $prefix . 'organization',
         'type' => 'text',
         'description' =>
@@ -91,19 +91,46 @@ function data()
     ]);
 
     $cmb->add_field([
-        'name' => __('Organization Link', 'pcc-framework'),
+        'name' => __('Project or Organization Link (DEPRECATED)', 'pcc-framework'),
         'id'   => $prefix . 'organization_link',
         'type' => 'text_url',
         'description' =>
-            __('A hyperlink organization with which this person is primarily affiliated.', 'pcc-framework'),
+            __('A hyperlink to the project/organization with which this person is primarily affiliated.<br />
+            <strong>THIS FIELD IS NO LONGER USED. ADD A LINK IN THE LINKS SECTION BELOW.</strong>', 'pcc-framework'),
     ]);
 
     $cmb->add_field([
-        'name'        => __('Twitter Username', 'pcc-framework'),
+        'name'        => __('Twitter Username (DEPRECATED)', 'pcc-framework'),
         'id'          => $prefix . 'twitter_username',
         'attributes'  => [ 'placeholder' => '@twitter' ],
         'type'        => 'text',
         'description' =>
-            __('The person&rsquo;s Twitter username.', 'pcc-framework'),
+            __('The person&rsquo;s Twitter username.<br />
+            <strong>THIS FIELD IS NO LONGER USED. ADD A LINK IN THE LINKS SECTION BELOW.</strong>', 'pcc-framework'),
+    ]);
+
+    $group_field_id = $cmb->add_field([
+        'id'          => $prefix . 'links',
+        'type'        => 'group',
+        'description' => __('Links which should be displayed on this person&rsquo;s profile.', 'pcc-framework'),
+        'options'     => [
+            'group_title'       => __('Link {#}', 'pcc-framework'),
+            'add_button'        => __('Add Another Link', 'pcc-framework'),
+            'remove_button'     => __('Remove Link', 'pcc-framework'),
+            'sortable'          => true,
+        ],
+    ]);
+
+    $cmb->add_group_field($group_field_id, [
+        'name' => __('Link', 'pcc-framework'),
+        'id'   => 'link',
+        'type' => 'text_url',
+    ]);
+
+    $cmb->add_group_field($group_field_id, [
+        'name' => __('Link Label (Optional)', 'pcc-framework'),
+        'description' => __('The name of the linked website.', 'pcc-framework'),
+        'id'   => 'label',
+        'type' => 'text',
     ]);
 }


### PR DESCRIPTION
* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

This PR adds a new repeating field group for profile links and link labels, replacing the Organization Link and Twitter Username fields.

## Steps to test

1. Add and save multiple links with optional labels.

**Expected behavior:** It works.

## Additional information

As per feedback, users may want multiple web and Twitter links and web links should not be closely tied to affiliations.

## Related issues

Not applicable.
