### PR TITLE
Add field to explicitly show people on people page

### DIFF
--- a/lib/posttypes/pcc-person.php
+++ b/lib/posttypes/pcc-person.php
@@ -133,4 +133,12 @@ function data()
         'id'   => 'label',
         'type' => 'text',
     ]);
+
+    $cmb->add_field([
+        'name'        => __('Show on People', 'pcc-framework'),
+        'id'          => $prefix . 'show_on_people',
+        'type'        => 'checkbox',
+        'description' =>
+            __('Should this person be shown on the main People page?', 'pcc-framework'),
+    ]);
 }

--- a/lib/posttypes/pcc-person.php
+++ b/lib/posttypes/pcc-person.php
@@ -135,7 +135,7 @@ function data()
     ]);
 
     $cmb->add_field([
-        'name'        => __('Show on People', 'pcc-framework'),
+        'name'        => __('Show on People page', 'pcc-framework'),
         'id'          => $prefix . 'show_on_people',
         'type'        => 'checkbox',
         'description' =>


### PR DESCRIPTION
* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

This PR adds an opt-in checkbox to each person which will allow them to be displayed on the People page. Many conference participants should not be shown there, so this is a prerequisite to https://github.com/platform-coop-toolkit/pcc/issues/84.

## Steps to test

1. Check and save the "Show on People page" checkbox.

**Expected behavior:** It saves properly.

## Additional information

Not applicable.

## Related issues

See https://github.com/platform-coop-toolkit/pcc/issues/84.