### PR TITLE
Add new short title field

### DIFF
--- a/lib/posttypes/pcc-person.php
+++ b/lib/posttypes/pcc-person.php
@@ -75,19 +75,30 @@ function data()
     ]);
 
     $cmb->add_field([
-        'name' => __('Title or Occupation', 'pcc-framework'),
-        'id'   => $prefix . 'title',
+        'name' => __('Short Title', 'pcc-framework'),
+        'id'   => $prefix . 'short_title',
         'type' => 'text',
-        'description' =>
-            __('The job title or occupation of this person.', 'pcc-framework'),
+        'description' => // @codingStandardsIgnoreStart
+            __('A short title which describes this person&rsquo;s work and primary affiliation that will be used on their card. For example: <br />
+            &ldquo;Founding Director, Institute for the Cooperative Digital Economy&rdquo;', 'pcc-framework'), // @codingStandardsIgnoreEnd
     ]);
 
     $cmb->add_field([
-        'name' => __('Project or Organization', 'pcc-framework'),
+        'name' => __('Full Title', 'pcc-framework'),
+        'id'   => $prefix . 'title',
+        'type' => 'textarea',
+        'description' => // @codingStandardsIgnoreStart
+            __('A full title which describes this person&rsquo;s work and affiliations that will be used on their page. For example:<br />
+            &ldquo;Founding Director of Institute for the Cooperative Digital Economy, Platform Cooperativism Consortium, The New School&rdquo;', 'pcc-framework'),
+    ]);
+
+    $cmb->add_field([
+        'name' => __('Project or Organization (DEPRECATED)', 'pcc-framework'),
         'id'   => $prefix . 'organization',
         'type' => 'text',
         'description' =>
-            __('The name of the organization with which this person is primarily affiliated.', 'pcc-framework'),
+            __('The name of the organization with which this person is primarily affiliated.<br />
+            <strong>THIS FIELD IS NO LONGER USED. INCLUDE THE PROJECT OR ORGANIZATION IN THE SHORT/FULL TITLE FIELDS ABOVE.</strong>', 'pcc-framework'),
     ]);
 
     $cmb->add_field([


### PR DESCRIPTION
* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

This PR adds a new Short Title field for People cards.

## Steps to test

1. Open a Person for editing.
2. Add a Short Title.

**Expected behavior:** It saves and is displayed in card views once https://github.com/platform-coop-toolkit/pcc/pull/130 is merged.

## Additional information

Not applicable.

## Related issues

- https://github.com/platform-coop-toolkit/pcc/pull/130