### PR TITLE
Add afragen/wp-dependency-installer and bundle CMB2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,9 +16,11 @@
     }
   ],
   "require": {
+    "afragen/wp-dependency-installer": "^2.0",
     "commerceguys/addressing": "^1.0",
     "davidgorges/human-name-parser": "^1.0",
-    "johnbillion/extended-cpts": "^4.2"
+    "johnbillion/extended-cpts": "^4.2",
+    "cmb2/cmb2": "^2.6"
   },
   "require-dev": {
     "phpunit/phpunit": "^6.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,134 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3852ad46093a31f92fae407a4f6ea6b3",
+    "content-hash": "36b3fc3315b420a271f7bbdd5b09d0cd",
     "packages": [
+        {
+            "name": "afragen/wp-dependency-installer",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/afragen/wp-dependency-installer.git",
+                "reference": "05ba1f94bf8268d1a66ebe6a3d510a78281d6d5d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/afragen/wp-dependency-installer/zipball/05ba1f94bf8268d1a66ebe6a3d510a78281d6d5d",
+                "reference": "05ba1f94bf8268d1a66ebe6a3d510a78281d6d5d",
+                "shasum": ""
+            },
+            "require": {
+                "collizo4sky/persist-admin-notices-dismissal": "^1",
+                "php": ">=5.6"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "wp-dependency-installer.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Andy Fragen",
+                    "email": "andy@thefragens.com",
+                    "homepage": "https://thefragens.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Matt Gibbs",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Library that helps WordPress plugin dependency management.",
+            "time": "2019-09-16T15:45:10+00:00"
+        },
+        {
+            "name": "cmb2/cmb2",
+            "version": "v2.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/CMB2/CMB2.git",
+                "reference": "008d9b83263d971d6bd41c27e31113db852d5ef3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/CMB2/CMB2/zipball/008d9b83263d971d6bd41c27e31113db852d5ef3",
+                "reference": "008d9b83263d971d6bd41c27e31113db852d5ef3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">5.2.4"
+            },
+            "require-dev": {
+                "apigen/apigen": "4.1.2",
+                "nette/utils": "2.5.3",
+                "phpunit/phpunit": "6.5.13"
+            },
+            "suggest": {
+                "composer/installers": "~1.0"
+            },
+            "type": "wordpress-plugin",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "WebDevStudios",
+                    "email": "contact@webdevstudios.com",
+                    "homepage": "https://github.com/WebDevStudios",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Justin Sternberg",
+                    "email": "justin@dsgnwrks.pro",
+                    "homepage": "https://dsgnwrks.pro",
+                    "role": "Developer"
+                }
+            ],
+            "description": "CMB2 is a metabox, custom fields, and forms library for WordPress that will blow your mind.",
+            "homepage": "https://github.com/CMB2/CMB2",
+            "keywords": [
+                "metabox",
+                "plugin",
+                "wordpress"
+            ],
+            "time": "2019-01-21T04:30:08+00:00"
+        },
+        {
+            "name": "collizo4sky/persist-admin-notices-dismissal",
+            "version": "1.4.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/collizo4sky/persist-admin-notices-dismissal.git",
+                "reference": "2d7d8bb3cba631ad227c92296a4b675d7cbc71d7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/collizo4sky/persist-admin-notices-dismissal/zipball/2d7d8bb3cba631ad227c92296a4b675d7cbc71d7",
+                "reference": "2d7d8bb3cba631ad227c92296a4b675d7cbc71d7",
+                "shasum": ""
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "persist-admin-notices-dismissal.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "authors": [
+                {
+                    "name": "Collins Agbonghama",
+                    "email": "me@w3guy.com"
+                }
+            ],
+            "description": "Simple library to persist dismissal of admin notices across pages in WordPress dashboard.",
+            "time": "2019-03-12T05:19:51+00:00"
+        },
         {
             "name": "commerceguys/addressing",
             "version": "v1.0.5",
@@ -383,18 +509,18 @@
             "authors": [
                 {
                     "name": "Arne Blankerts",
-                    "role": "Developer",
-                    "email": "arne@blankerts.de"
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
                 },
                 {
                     "name": "Sebastian Heuer",
-                    "role": "Developer",
-                    "email": "sebastian@phpeople.de"
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
                 },
                 {
                     "name": "Sebastian Bergmann",
-                    "role": "Developer",
-                    "email": "sebastian@phpunit.de"
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
                 }
             ],
             "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
@@ -430,18 +556,18 @@
             "authors": [
                 {
                     "name": "Arne Blankerts",
-                    "role": "Developer",
-                    "email": "arne@blankerts.de"
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
                 },
                 {
                     "name": "Sebastian Heuer",
-                    "role": "Developer",
-                    "email": "sebastian@phpeople.de"
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
                 },
                 {
                     "name": "Sebastian Bergmann",
-                    "role": "Developer",
-                    "email": "sebastian@phpunit.de"
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
                 }
             ],
             "description": "Library for handling version information and constraints",
@@ -712,8 +838,8 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "role": "lead",
-                    "email": "sebastian@phpunit.de"
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
                 }
             ],
             "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
@@ -760,8 +886,8 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "role": "lead",
-                    "email": "sb@sebastian-bergmann.de"
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
                 }
             ],
             "description": "FilterIterator implementation that filters files based on a list of suffixes.",
@@ -802,8 +928,8 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "role": "lead",
-                    "email": "sebastian@phpunit.de"
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
                 }
             ],
             "description": "Simple template engine.",
@@ -851,8 +977,8 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "role": "lead",
-                    "email": "sb@sebastian-bergmann.de"
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
                 }
             ],
             "description": "Utility class for timing",
@@ -982,8 +1108,8 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "role": "lead",
-                    "email": "sebastian@phpunit.de"
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
                 }
             ],
             "description": "The PHP Unit Testing framework.",
@@ -1606,8 +1732,8 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "role": "lead",
-                    "email": "sebastian@phpunit.de"
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
                 }
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
@@ -1783,8 +1909,8 @@
             "authors": [
                 {
                     "name": "Arne Blankerts",
-                    "role": "Developer",
-                    "email": "arne@blankerts.de"
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
                 }
             ],
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",

--- a/pcc-framework.php
+++ b/pcc-framework.php
@@ -40,6 +40,11 @@ if (!function_exists('register_extended_post_type')) {
 }
 
 /**
+ * Load CMB2.
+ */
+require_once __DIR__ . '/vendor/cmb2/cmb2/init.php';
+
+/**
  * Load and register post types.
  */
 foreach ([
@@ -108,3 +113,8 @@ if (is_admin()) {
 require_once dirname(__FILE__) . "/lib/embeds.php";
 
 PCCFramework\Embeds\init_livestream();
+
+/**
+ * Run dependency installer.
+ */
+WP_Dependency_Installer::instance()->run(__DIR__);

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -2,6 +2,9 @@
 <ruleset name="Roots">
   <description>Roots Coding Standards</description>
 
+  <!-- Exclude vendor -->
+  <exclude-pattern>vendor/*</exclude-pattern>
+
   <!-- Show colors in console -->
   <arg value="-colors"/>
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -2,7 +2,8 @@
 <ruleset name="Roots">
   <description>Roots Coding Standards</description>
 
-  <!-- Exclude vendor -->
+  <!-- Exclude tests/ and vendor/ -->
+  <exclude-pattern>tests/*</exclude-pattern>
   <exclude-pattern>vendor/*</exclude-pattern>
 
   <!-- Show colors in console -->

--- a/tests/test-utils.php
+++ b/tests/test-utils.php
@@ -10,17 +10,22 @@ use function PCCFramework\Utils\get_config_option;
 /**
  * Utils tests.
  */
-class UtilsTest extends WP_UnitTestCase {
+class UtilsTest extends WP_UnitTestCase
+{
 
-	/**
-	 * A single example test.
-	 */
-	public function test_get_config_option() {
+    /**
+     * A single example test.
+     */
+    public function test_get_config_option()
+    {
+        $result = get_config_option('my_key', 'my_default_value');
+        $this->assertEquals('my_default_value', $result);
         update_option('platformcoop_configuration', ['my_key' => 'my_value']);
-        $result = get_config_option('my_key', ['my_key' => 'my_default_value']);
+        $result = get_config_option('my_key', 'my_default_value');
         $this->assertEquals('my_value', $result);
+        echo $result;
         delete_option('platformcoop_configuration');
-        $result = get_config_option('my_other_key', ['my_other_key' => 'my_other_default_value']);
-		$this->assertEquals('my_other_default_value', $result);
-	}
+        $result = get_config_option('my_other_key', 'my_other_default_value');
+        $this->assertEquals('my_other_default_value', $result);
+    }
 }

--- a/wp-dependencies.json
+++ b/wp-dependencies.json
@@ -1,0 +1,53 @@
+[
+  {
+    "name": "Contact Form 7",
+    "host": "wordpress",
+    "slug": "contact-form-7/wp-contact-form-7.php",
+    "uri": "https://wordpress.org/plugins/contact-form-7/",
+    "optional": false
+  },
+  {
+    "name": "Redirection",
+    "host": "wordpress",
+    "slug": "redirection/redirection.php",
+    "uri": "https://wordpress.org/plugins/redirection/",
+    "optional": true
+  },
+  {
+    "name": "Simple Page Ordering",
+    "host": "wordpress",
+    "slug": "simple-page-ordering/simple-page-ordering.php",
+    "uri": "https://wordpress.org/plugins/simple-page-ordering/",
+    "optional": false
+  },
+  {
+    "name": "The SEO Framework",
+    "host": "wordpress",
+    "slug": "autodescription/autodescription.php",
+    "uri": "https://wordpress.org/plugins/autodescription/",
+    "optional": true
+  },
+  {
+    "name": "WP CLI Login Server",
+    "host": "github",
+    "slug": "wp-cli-login-server/wp-cli-login-server.php",
+    "uri": "https://github.com/aaemnnosttv/wp-cli-login-server",
+    "branch": "master",
+    "optional": true
+  },
+  {
+    "name": "WP Stage Switcher",
+    "host": "github",
+    "slug": "wp-stage-switcher/wp-stage-switcher.php",
+    "uri": "https://github.com/roots/wp-stage-switcher",
+    "branch": "master",
+    "optional": false
+  },
+  {
+    "name": "WP Toolbelt",
+    "host": "wordpress",
+    "slug": "wp-toolbelt/index.php",
+    "uri": "https://wordpress.org/plugins/wp-toolbelt/",
+    "optional": true
+  }
+]


### PR DESCRIPTION
* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

This PR adds [afragen/wp-dependency-installer](https://github.com/afragen/wp-dependency-installer) to automatically install required plugins, and loads CMB2 as a Composer dependency instead of requiring that the plugin be installed.

## Steps to test

1. Install and activated the updated plugin.

**Expected behavior:** Required plugin dependencies are loaded automatically.

## Additional information

Not applicable.

## Related issues

Not applicable.
