### PR TITLE
Support newlines in venue name

### DIFF
--- a/lib/posttypes/pcc-event.php
+++ b/lib/posttypes/pcc-event.php
@@ -110,7 +110,7 @@ function data()
     $cmb->add_field([
         'name' => __('Venue Name', 'pcc-framework'),
         'id'   => $prefix . 'venue',
-        'type' => 'text',
+        'type' => 'textarea_small',
         'description' =>
             __('The name of the event&rsquo;s principal venue.', 'pcc-framework'),
     ]);


### PR DESCRIPTION
* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

Allows new lines in venue name (related to platform-coop-toolkit/pcc#169).

## Steps to test

1. Add or edit an event.

**Expected behavior:** Confirm that newlines can be used in the venue name field.

## Additional information

Not applicable.

## Related issues

- Related to platform-coop-toolkit/pcc#169
