### PR TITLE
Move Intervention to plugin dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,7 @@
     "commerceguys/addressing": "^1.0",
     "composer/installers": "^1.7",
     "davidgorges/human-name-parser": "^1.0",
-    "johnbillion/extended-cpts": "^4.2",
-    "soberwp/intervention": "1.2.0-p"
+    "johnbillion/extended-cpts": "^4.2"
   },
   "require-dev": {
     "phpunit/phpunit": "^6.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0e83db1072a2c1e4d10d536cdac23b1d",
+    "content-hash": "d34823b426f2e84cb037091e325d305f",
     "packages": [
         {
             "name": "afragen/wp-dependency-installer",
@@ -486,55 +486,6 @@
             "description": "A library which provides extended functionality to WordPress custom post types and taxonomies.",
             "homepage": "https://github.com/johnbillion/extended-cpts/",
             "time": "2019-08-25T21:14:07+00:00"
-        },
-        {
-            "name": "soberwp/intervention",
-            "version": "1.2.0-p",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/soberwp/intervention.git",
-                "reference": "1698e51efe696c5867fb78ef7c5d2efff9b79260"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/soberwp/intervention/zipball/1698e51efe696c5867fb78ef7c5d2efff9b79260",
-                "reference": "1698e51efe696c5867fb78ef7c5d2efff9b79260",
-                "shasum": ""
-            },
-            "require": {
-                "composer/installers": "~1.0",
-                "php": ">=5.4.0"
-            },
-            "require-dev": {
-                "squizlabs/php_codesniffer": "2.*"
-            },
-            "type": "package",
-            "autoload": {
-                "psr-4": {
-                    "Sober\\Intervention\\": "src/",
-                    "Sober\\Intervention\\Module\\": "src/modules/"
-                },
-                "files": [
-                    "intervention.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Darren Jacoby",
-                    "email": "darren@jacoby.co.za",
-                    "homepage": "https://twitter.com/withjacoby"
-                }
-            ],
-            "description": "WordPress plugin containing modules to cleanup and customize wp-admin.",
-            "homepage": "https://github.com/soberwp",
-            "keywords": [
-                "wordpress"
-            ],
-            "time": "2017-08-26T12:21:27+00:00"
         }
     ],
     "packages-dev": [

--- a/wp-dependencies.json
+++ b/wp-dependencies.json
@@ -7,6 +7,14 @@
     "optional": false
   },
   {
+    "name": "Intervention",
+    "host": "github",
+    "slug": "intervention/intervention.php",
+    "uri": "https://github.com/soberwp/intervention",
+    "branch": "master",
+    "optional": false
+  },
+  {
     "name": "Redirection",
     "host": "wordpress",
     "slug": "redirection/redirection.php",


### PR DESCRIPTION
* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

Package wasn't working. Supercedes #83.

## Steps to test

1. Load plugin.

**Expected behavior:** Intervention plugin dependency is installed.

## Additional information

Not applicable.

## Related issues

- Supercedes #83.
