### PR TITLE
Add support for custom authors

### DIFF
--- a/lib/posttypes/pcc-post.php
+++ b/lib/posttypes/pcc-post.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace PCCFramework\PostTypes\Post;
+
+/**
+ * Registers meta for the the `pcc-person` post type.
+ */
+function register_meta()
+{
+    register_post_meta('post', 'pcc_post_authors', [
+        'type' => 'integer',
+        'description' => 'The IDs of the people who authored this post.',
+        'single' => false,
+        'show_in_rest' => true,
+    ]);
+}
+
+/**
+ * Registers the Post Data metabox and meta fields.
+ *
+ * @return null
+ */
+function data()
+{
+    $people = get_posts(['post_type' => 'pcc-person', 'numberposts' => -1]);
+    $options = [];
+    foreach ($people as $person) {
+        $options[$person->ID] = $person->post_title;
+    }
+    asort($options);
+
+    $prefix = 'pcc_post_';
+
+    $cmb = new_cmb2_box([
+        'id'            => 'post_data',
+        'title'         => __('Post Data', 'pcc-framework'),
+        'object_types'  => ['post'],
+        'context'       => 'normal',
+        'priority'      => 'high',
+        'show_names'    => true,
+    ]);
+
+    $cmb->add_field([
+        'name' => __('Post Author', 'pcc-framework'),
+        'id'   => $prefix . 'authors',
+        'type' => 'select',
+        'show_option_none' => true,
+        'options'          => $options,
+        'description' =>
+            __('The author of this post (use this if they do not have a WordPress account).', 'pcc-framework'),
+    ]);
+}

--- a/pcc-framework.php
+++ b/pcc-framework.php
@@ -51,10 +51,13 @@ foreach ([
     'attachment',
     'event',
     'person',
+    'post'
 ] as $posttype) {
     require_once dirname(__FILE__) . "/lib/posttypes/pcc-$posttype.php";
     if ($posttype !== 'attachment') {
-        add_action('init', '\\PCCFramework\\PostTypes\\' . ucfirst($posttype) . '\\init');
+        if ($posttype !== 'post') {
+            add_action('init', '\\PCCFramework\\PostTypes\\' . ucfirst($posttype) . '\\init');
+        }
         add_action('init', '\\PCCFramework\\PostTypes\\' . ucfirst($posttype) . '\\register_meta');
     }
 }
@@ -101,6 +104,7 @@ if (is_admin()) {
     add_action('cmb2_admin_init', '\\PCCFramework\\PostTypes\\Event\\data');
     add_action('cmb2_admin_init', '\\PCCFramework\\PostTypes\\Event\\sponsors');
     add_action('cmb2_admin_init', '\\PCCFramework\\PostTypes\\Person\\data');
+    add_action('cmb2_admin_init', '\\PCCFramework\\PostTypes\\Post\\data');
     add_action('cmb2_admin_init', '\\PCCFramework\\Settings\\page');
     add_filter('attachment_fields_to_edit', '\\PCCFramework\\PostTypes\\Attachment\\data', 10, 2);
     add_action('edit_attachment', '\\PCCFramework\\PostTypes\\Attachment\\save');


### PR DESCRIPTION
* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

Add meta field for choosing a custom post author from People.

## Steps to test

Edit a post, select a custom author from the sidebar, and save changes.

**Expected behavior:** The value is saved.

## Additional information

Not applicable.

## Related issues

Not applicable.
