### PR TITLE
fix: address mailing list bug in recent content block

### DIFF
--- a/lib/blocks/recent-content.php
+++ b/lib/blocks/recent-content.php
@@ -81,8 +81,8 @@ function render_callback($attributes)
         </li>
         <?php }
         wp_reset_postdata();
-        $newsletter_link = (function_exists('\PlatformCoop\Utils\get_config_option'))
-        ? get_config_option(
+        $newsletter_link = (function_exists('\PCCFramework\Utils\get_config_option'))
+        ? \PCCFramework\Utils\get_config_option(
             'signup_link',
             'https://lists.riseup.net/www/info/platformcoop-newsletter'
         )

--- a/lib/blocks/recent-content.php
+++ b/lib/blocks/recent-content.php
@@ -84,9 +84,9 @@ function render_callback($attributes)
         $newsletter_link = (function_exists('\PCCFramework\Utils\get_config_option'))
         ? \PCCFramework\Utils\get_config_option(
             'signup_link',
-            'https://lists.riseup.net/www/info/platformcoop-newsletter'
+            'https://mailchi.mp/platform/coop'
         )
-        : 'https://lists.riseup.net/www/info/platformcoop-newsletter';
+        : 'https://mailchi.mp/platform/coop';
         ?>
         <li class="card card--7">
             <div class="card__details">


### PR DESCRIPTION
* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

Use the correct mailing list in recent content.

## Steps to test

1. Visit home page.

**Expected behavior:** "Never miss an update" links to the MailChimp list.

## Additional information

Not applicable.

## Related issues

Not applicable.
